### PR TITLE
Use getline and append for reading shader code

### DIFF
--- a/framework/source/utils.cpp
+++ b/framework/source/utils.cpp
@@ -102,21 +102,24 @@ void output_log(GLchar const* log_buffer, std::string const& prefix) {
 }
 
 std::string read_file(std::string const& name) {
-  std::ifstream file_in{name};
-  if(file_in) {
-    std::string contents;
-    file_in.seekg(0, std::ios::end);
-    contents.resize(file_in.tellg());
-    file_in.seekg(0, std::ios::beg);
-    file_in.read(&contents[0], contents.size());
-    file_in.close();
-    return(contents);
+  std::ifstream ifile(name);
+
+  if(ifile) {
+    std::string filetext;
+    
+    while(ifile.good()) {
+      std::string line;
+      std::getline(ifile, line);
+      filetext.append(line + "\n");
+    }
+    
+    return filetext; 
   }
   else {
     std::cerr << "File \'" << name << "\' not found" << std::endl;
     
     throw std::invalid_argument(name);
-  } 
+  }
 }
 
 };


### PR DESCRIPTION
Using the old method for reading the shader code from an external file can cause garbage to be read on Windows systems with MinGW configurations (possibly due to character encoding complications). This method is simpler, relying only on getline and append to read from the shader file. This also ensures correct line breaks, which when missing can also throw off the GLSL compiler.

The new code seems to be robust against encoding changes and has been tested with UTF-8, ANSI, Windows-1250, Windows-1252 and ISO-8859-2 encoding schemes and both Unix and Windows line endings on Windows 7 with MinGW-64 5.0 and macOS 10.12.